### PR TITLE
BUG: Fix incorrect shape by adding multichannel=True

### DIFF
--- a/compare_to_opencv.py
+++ b/compare_to_opencv.py
@@ -86,7 +86,7 @@ def main():
     ))):
         if d is not None:
             # TODO: account for shapes not quite matching
-            d = skimage.transform.pyramid_expand(d)
+            d = skimage.transform.pyramid_expand(d, multichannel=True)
             d = d[:pyr1.shape[0], :pyr2.shape[1]]
 
         d = flow_iterative(pyr1, pyr2, c1=c1_, c2=c2_, d=d, **opts)


### PR DESCRIPTION
The default behavior for scikit-image pyramid_expand changed
in version 0.16. This parameter must now be explicitly set to
get the desired behavior.